### PR TITLE
Correct module name in Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn facebookbot:app
+web: gunicorn facebook-echobot-standalone:app


### PR DESCRIPTION
In this project, the module is called `facebook-echobot-standalone` instead of `facebookbot`.